### PR TITLE
fix: set march flag and __archspec dependencies on x86_64 unit targets

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,9 @@ source:
 build:
   script:
     - export CMAKE_GENERATOR=Ninja  # [unix]
-    - {{ PYTHON }} -m pip install . -vv --config-settings=cmake.verbose=true --config-settings=logging.level=DEBUG
-  number: 0
+    - {{ PYTHON }} -m pip install . -vv -Ccmake.verbose=true -Clogging.level=DEBUG -Ccmake.define.MULTISPLINE_MARCH=x86-64-v2  # [unix and x86_64]
+    - {{ PYTHON }} -m pip install . -vv -Ccmake.verbose=true -Clogging.level=DEBUG  # [(not unix) or (not x86_64)]
+  number: 1
   skip: true  # [py<39]
 
 requirements:
@@ -39,6 +40,7 @@ requirements:
   run:
     - python
     - numpy
+    - __archspec 1=x86_64_v2  # [unix and x86_64]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,6 @@ requirements:
   run:
     - python
     - numpy
-    - __archspec 1=x86_64_v2  # [unix and x86_64]
 
 test:
   source_files:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~~Reset the build number to `0` (if the version changed)~~
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

On some platform, executing multispline led to SIGILL exceptions being raised (for instance on an AMD EPYC 7713 64-Core Processor).

This was probably due to `-march` being set to `native` by default. Now, on linux x86_64 platforms, the flag is set to `-march=x86-64-v2` ~~and a run dependency is defined on `__archspec 1=x86_64_v2`~~ (run dependency removed after finding it's not the recommended approach. Waiting for official guidelines on constraining micro-architecture).

<!--
Please add any other relevant info below:
-->

