### PR TITLE
fix: compilation flag for microarch level = 1

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,10 +3,14 @@ schema_version: 1
 context:
   name: multispline
   version: 0.8.5
-  build: 3
-  microarch_level: ${{ 1 if microarch_level is undefined else (microarch_level | int) }}
+  build: 4
+  microarch_level: ${{ 1 if microarch_level is undefined else microarch_level }}
   build_with_microarch: ${{ build + (microarch_level * 100) | int }}
-  microarch_option: ${{ "-Ccmake.define.MULTISPLINE_MARCH=x86-64-v" ~ microarch_level if (unix and x86_64) else "" }}
+  microarch_option: ${{ ("-Ccmake.define.MULTISPLINE_MARCH=x86-64-v" ~ microarch_level 
+                    if (microarch_level | int) > 1 
+                    else "-Ccmake.define.MULTISPLINE_MARCH=x86-64") 
+                         if (unix and x86_64)
+                         else ""}}
 
 package:
   name: ${{ name|lower }}
@@ -22,7 +26,11 @@ build:
   script:
     - if: unix
       then: export CMAKE_GENERATOR=Ninja
-    - ${{ PYTHON }} -m pip install . -vv  -Ccmake.verbose=true -Clogging.level=DEBUG ${{ microarch_option }}
+    - >-
+      ${{ PYTHON }} -m pip install . -vv 
+      -Ccmake.verbose=true
+      -Clogging.level=DEBUG
+      ${{ microarch_option }}
 
 requirements:
   build:
@@ -39,7 +47,7 @@ requirements:
     - ninja
     - cmake
     - make
-    - if: unix and x86_64 and (microarch_level <= 3)
+    - if: unix and x86_64 and microarch_level < 4
       then: x86_64-microarch-level ${{ microarch_level }}.*
   host:
     - python
@@ -50,7 +58,7 @@ requirements:
   run:
     - python
     - numpy
-    - if: unix and x86_64 and (microarch_level >= 4)
+    - if: unix and x86_64 and microarch_level == 4
       then: _x86_64-microarch-level >=${{ microarch_level }}
 
 tests:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Similarly to https://github.com/conda-forge/fastemriwaveforms-feedstock/pull/9 , this PR fixes the way `microarch_level=1` option is handled. Previously, it added the compilation flag `-march=x86-64-v1` which fails and should have been `-march=x86-64`.

Some aesthetic changes are also made to homogenise the recipe styles between FEW and multispline.